### PR TITLE
word-break css for status-content

### DIFF
--- a/src/components/StatusCard.vue
+++ b/src/components/StatusCard.vue
@@ -770,6 +770,8 @@
 <style lang="scss">
 
   .status-content {
+    // https://stackoverflow.com/questions/5241369/word-wrap-a-link-so-it-doesnt-overflow-its-parent-div-width
+    word-wrap: break-word;
     > p {
       margin: 0;
       padding: 0;


### PR DESCRIPTION
Resolves #42 
<img width="553" alt="screen shot 2018-10-20 at 9 23 04 pm" src="https://user-images.githubusercontent.com/3515852/47263069-87a5fb00-d4ae-11e8-8ead-9fa39988e9d1.png">
