### PR TITLE
Pleroma support

### DIFF
--- a/src/pages/OAuth.vue
+++ b/src/pages/OAuth.vue
@@ -103,7 +103,8 @@
     }
 
     goToMastodonServerForOAuth () {
-      window.location.href = `${this.prefix + this.validateForm.mastodonServerUri}/oauth/authorize?client_id=${this.OAuthInfo.clientId}` +
+      window.location.href = `${this.prefix + this.validateForm.mastodonServerUri}/oauth/authorize` +
+        `?client_id=` + encodeURIComponent(this.OAuthInfo.clientId) +
         `&redirect_uri=${location.origin}` +
         `&response_type=code&scope=read write follow`
     }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -103,9 +103,9 @@ function checkShouldRegisterApplication (to, from): boolean {
 
   let code = store.state.OAuthInfo.code
   if (from.path === '/' && !code) {
-    if (location.href.indexOf("?code=") !== -1) {
-      code = location.href.replace(location.origin + location.pathname + "?code=", "")
-      code = code.replace('#/', '')
+    if (location.search.substring(0,6) == "?code=") {
+      code = (new RegExp("[\\?&]code=([^&#]*)")).exec(location.search)
+      code = code == null ? "": decodeURIComponent(code[1]);
       // todo maybe shouldn't put this here?
       store.commit('updateOAuthCode', code)
     }


### PR DESCRIPTION
first commit is to fix #92 which pleroma instances will return base64-encoded client_id with `=` paddings
second commit is to fix #91 as pleroma instances will return `state` parameter as well, which breaks current accessToken parsing